### PR TITLE
Double equals doesn't work between single brackets

### DIFF
--- a/files/suspend/rmmod_tb.sh
+++ b/files/suspend/rmmod_tb.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
-if [ "${1}" == "pre" ]; then
+if [ "${1}" = "pre" ]; then
         modprobe -r apple_ib_tb
-elif [ "${1}" == "post" ]; then
+elif [ "${1}" = "post" ]; then
         modprobe apple_ib_tb
 fi


### PR DESCRIPTION
the POSIX standard doesn't require `==` to work between single brackets, this only works in bash. This change should fix the touchbar failing to reinitialize after suspend.