### PR TITLE
Fedora 34 readme changes

### DIFF
--- a/fedora-mbp.ks
+++ b/fedora-mbp.ks
@@ -24,12 +24,12 @@ wpa_supplicant
 -kernel-modules-5.*.fc34.x86_64
 -kernel-modules-extra-5.*.fc34.x86_64
 -kernel-modules-internal-5.*.fc34.x86_64
-kernel-5.13.10-200.mbp16.fc33.x86_64
-kernel-core-5.13.10-200.mbp16.fc33.x86_64
-kernel-devel-5.13.10-200.mbp16.fc33.x86_64
-kernel-modules-5.13.10-200.mbp16.fc33.x86_64
-kernel-modules-extra-5.13.10-200.mbp16.fc33.x86_64
-kernel-modules-internal-5.13.10-200.mbp16.fc33.x86_64
+kernel-5.13.10-200.mbp15.fc33.x86_64
+kernel-core-5.13.10-200.mbp15.fc33.x86_64
+kernel-devel-5.13.10-200.mbp15.fc33.x86_64
+kernel-modules-5.13.10-200.mbp15.fc33.x86_64
+kernel-modules-extra-5.13.10-200.mbp15.fc33.x86_64
+kernel-modules-internal-5.13.10-200.mbp15.fc33.x86_64
 
 %end
 
@@ -38,7 +38,7 @@ kernel-modules-internal-5.13.10-200.mbp16.fc33.x86_64
 ### Add dns server configuration
 echo 'nameserver 8.8.8.8' > /etc/resolv.conf
 
-KERNEL_VERSION=5.13.10-200.mbp16.fc33.x86_64
+KERNEL_VERSION=5.13.10-200.mbp15.fc33.x86_64
 BCE_DRIVER_GIT_URL=https://github.com/t2linux/apple-bce-drv
 BCE_DRIVER_BRANCH_NAME=aur
 BCE_DRIVER_COMMIT_HASH=f93c6566f98b3c95677de8010f7445fa19f75091


### PR DESCRIPTION
TODO: 
- Add sound patches
- Add BLS support
- Add info to readme about:
  - dgpu - https://github.com/mikeeq/mbp-fedora/issues/25
  - https://wiki.t2linux.org/guides/hybrid-graphics/
  - disable igpu 
  - mbp15,16 kernel
  - audio
- latest version of livecd-tools

```
# https://travis-ci.com/github/mikeeq/mbp-fedora/jobs/517205307#L6956
The 'rhgb' entity is not available.
The '/usr/lib/anaconda-runtime/checkisomd5' entity is not available.
Traceback (most recent call last):
  File "/usr/sbin/mkefiboot", line 168, in <module>
    main()
  File "/usr/sbin/mkefiboot", line 161, in main
    mkefiboot(opt.bootdir, opt.outfile, opt.label)
  File "/usr/sbin/mkefiboot", line 33, in mkefiboot
    mkdosimg(None, outfile, label=label, graft={'EFI/BOOT':bootdir})
  File "/usr/lib/python3.9/site-packages/pylorax/imgutils.py", line 551, in mkdosimg
    mkfsimage("msdos", rootdir, outfile, size, mountargs=mountargs,
  File "/usr/lib/python3.9/site-packages/pylorax/imgutils.py", line 525, in mkfsimage
    with LoopDev(outfile, size) as loopdev:
  File "/usr/lib/python3.9/site-packages/pylorax/imgutils.py", line 355, in __init__
    mksparse(self.filename, size)
  File "/usr/lib/python3.9/site-packages/pylorax/imgutils.py", line 143, in mksparse
    with open(outfile, "w") as fobj:
FileNotFoundError: [Errno 2] No such file or directory: '/var/tmp/imgcreate-z8s7wf7o/iso-ncy0k0u_/images/efiboot.img'
Traceback (most recent call last):
  File "/usr/sbin/mkefiboot", line 168, in <module>
    main()
  File "/usr/sbin/mkefiboot", line 158, in main
    mkmacboot(opt.bootdir, opt.outfile, opt.label, opt.icon, opt.product,
  File "/usr/sbin/mkefiboot", line 45, in mkmacboot
    mkhfsimg(None, outfile, label=label, graft=graft, size=size)
  File "/usr/lib/python3.9/site-packages/pylorax/imgutils.py", line 566, in mkhfsimg
    mkfsimage("hfsplus", rootdir, outfile, size, mountargs=mountargs,
  File "/usr/lib/python3.9/site-packages/pylorax/imgutils.py", line 525, in mkfsimage
    with LoopDev(outfile, size) as loopdev:
  File "/usr/lib/python3.9/site-packages/pylorax/imgutils.py", line 355, in __init__
    mksparse(self.filename, size)
  File "/usr/lib/python3.9/site-packages/pylorax/imgutils.py", line 143, in mksparse
    with open(outfile, "w") as fobj:
FileNotFoundError: [Errno 2] No such file or directory: '/var/tmp/imgcreate-z8s7wf7o/iso-ncy0k0u_/images/macboot.img'
```