### PR TITLE
fix for suspend script

### DIFF
--- a/files/suspend/rmmod_tb.sh
+++ b/files/suspend/rmmod_tb.sh
@@ -1,8 +1,10 @@
 #!/bin/sh
 if [ "${1}" = "pre" ]; then
   modprobe -r apple_ib_tb
+  modprobe -r apple_ib_als
   modprobe -r hid_apple
 elif [ "${1}" = "post" ]; then
   modprobe hid_apple
+  modprobe apple_ib_als
   modprobe apple_ib_tb
 fi


### PR DESCRIPTION
Current script was still causing my system to freeze after resume. (MacBookPro16,1).
I'm also removing `apple_ib_als` module before suspend.

Not sure if this is needed for every MacBook.