### PR TITLE
Update README with note for Wi-Fi on 16 inch mbp

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ macOS Mojave: 10.14.6 (18G103)
     ```
 
 - To install additional languages, install appropriate langpack via dnf `dnf search langpack`
-- After login you can update kernel by running `sudo update_kernel_mbp`, more info here: <https://github.com/mikeeq/mbp-fedora-kernel#how-to-update-kernel-mbp>
+- After login you can update kernel by running `sudo update_kernel_mbp`, more info here: <https://github.com/mikeeq/mbp-fedora-kernel#how-to-update-kernel-mbp> (to enable Wi-Fi on 16 inch models you need to pass extra parameters, this link has the details).
 - You can change mappings of ctrl, option keys (PC keyboard mappings) by creating `/etc/modprobe.d/hid_apple.conf` file and recreating grub config. All available modifications could be found here: <https://github.com/free5lot/hid-apple-patched>
 
   ```bash


### PR DESCRIPTION
When I followed the README the first time using my 16 inch MBP, I ran `sudo update_kernel_mbp` as the instructions say, but I didn't realise I needed an extra parameter to update to mpb16 until someone pointed it out on Discord. I think this note would be enough to help others having the same issue.